### PR TITLE
CFU Playground needs numpy 1.22.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.9
   - gym >= 0.17.2
-  - numpy=1.21.5
+  - numpy=1.22.4
   - pandas
   - seaborn
   - requests


### PR DESCRIPTION
I tested all vizier and ga, aco, bo, and rw agents with DRAMSys with this numpy version change to make sure they were still working.