### PR TITLE
Remove jupyter for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ plotly
 scons
 portpicker
 dill
-jupyter


### PR DESCRIPTION
There is a dependency conflict between jupyter and vizier that pip can not resolve it appears. So jupyter has to be installed after vizier to have the correct package installed. Let's remove jupyter for now then and users can pip install jupyter themselves if them want to use the notebooks. We can create a page on the documentation for notebooks and make sure this step is reflected. Sound good @srivatsankrishnan? I tested and notebook works fine though once you have right version installed. 