### PR TITLE
Changed config file for timeloop

### DIFF
--- a/configs/sims/Timeloop_config.py
+++ b/configs/sims/Timeloop_config.py
@@ -42,3 +42,9 @@ target_cycle_improv  = 0.2
 target_energy = 29206   * (1 - target_energy_improv)
 target_area   = 2.03    * (1 - target_area_improv)
 target_cycles = 7885704 * (1 - target_cycle_improv)
+
+##########################
+#   ACO  Configurations  #
+##########################
+# ACO
+aco_config = "default_astrasim.yaml"

--- a/sims/Timeloop/launch_gcp.py
+++ b/sims/Timeloop/launch_gcp.py
@@ -7,7 +7,7 @@ import yaml
 import json
 from datetime import date, datetime
 os.sys.path.insert(0, os.path.abspath('../../'))
-from configs import arch_gym_configs
+from configs.sims import Timeloop_config
 
 from absl import flags
 from absl import app
@@ -164,9 +164,9 @@ def run_task(task):
         reward_formulation = task['reward_formulation']
 
         aco_agent_config_file = os.path.join(
-                                arch_gym_configs.proj_root_path,
+                                Timeloop_config.proj_root_path,
                                 "settings",
-                                arch_gym_configs.aco_config)
+                                Timeloop_config.aco_config)
         aco_hyperparams = {"evaporation": evaporation,
                             "ant_count": ant_count,
                             "greediness": greediness,
@@ -275,7 +275,6 @@ def run_task(task):
 
 def main(_):
     taskList = []
-    sim_config = arch_gym_configs.sim_config
 
     if FLAGS.algo == 'rw':
         task = {'algo': FLAGS.algo,


### PR DESCRIPTION
Changed the way the config file is imported in launch_gcp for timeloop, also added a aco_config for Timeloop_config file as it is used in launch_gcp, removed the sim_config as not used anywhere. 